### PR TITLE
Используем встроенный GITHUB_TOKEN вместо доп.секрета PUSH_TOKEN, который теперь не нужен

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ jobs:
     with:
       package_mask: "annotations-*.ospx" # change me!
     secrets:
-      PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+      PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
обсуждение в https://t.me/oscript_library/124110

v8runner v1.10.0 успешно опубликовался в таком варианте