### PR TITLE
feat: пропуск тестов и сонара при push, если для ветки открыт PR

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -108,7 +108,44 @@ on:
 
 jobs:
 
+  check-pr-exists:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      has_pr: ${{ steps.check.outputs.has_pr }}
+    steps:
+      - name: Проверка наличия pull request для ветки
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -e
+          # При push в ветку, для которой уже открыт pull request, контроль
+          # качества будет выполнен в рамках события pull_request, поэтому
+          # повторный запуск для события push пропускается во избежание
+          # дублирования прогонов.
+          if [ "$EVENT_NAME" == "push" ] \
+            && [ "$REF_NAME" != "$DEFAULT_BRANCH" ] \
+            && [ "$REF_NAME" != "master" ] \
+            && [ "$REF_NAME" != "develop" ]; then
+            prs=$(gh pr list --repo "$REPOSITORY" --head "$REF_NAME" --state open --json number --jq 'length')
+            if [ "$prs" -gt 0 ]; then
+              echo "has_pr=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_pr=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: [check-pr-exists]
+    if: needs.check-pr-exists.outputs.has_pr != 'true'
     runs-on: ${{ inputs.os_version }}
     env:
       LANG: ${{ inputs.locale }}.UTF-8
@@ -217,8 +254,8 @@ jobs:
 
   sonar:
     runs-on: ${{ inputs.os_version }}
-    needs: [test]
-    if: ${{ (inputs.sonarqube == true) && (github.repository == inputs.github_repository) && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.event.repository.full_name) }} 
+    needs: [check-pr-exists, test]
+    if: ${{ (needs.check-pr-exists.outputs.has_pr != 'true') && (inputs.sonarqube == true) && (github.repository == inputs.github_repository) && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.event.repository.full_name) }}
     steps:
       - name: Актуализация
         uses: actions/checkout@v6.0.2
@@ -267,8 +304,8 @@ jobs:
 
   coveralls:
     runs-on: ${{ inputs.os_version }}
-    if: inputs.coveralls == true
-    needs: [test]
+    if: ${{ (needs.check-pr-exists.outputs.has_pr != 'true') && (inputs.coveralls == true) }}
+    needs: [check-pr-exists, test]
     steps:
       - name: Актуализация
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -131,6 +131,7 @@ jobs:
           # дублирования прогонов.
           if [ "$EVENT_NAME" == "push" ] \
             && [ "$REF_NAME" != "$DEFAULT_BRANCH" ] \
+            && [ "$REF_NAME" != "main" ] \
             && [ "$REF_NAME" != "master" ] \
             && [ "$REF_NAME" != "develop" ]; then
             prs=$(gh pr list --repo "$REPOSITORY" --head "$REF_NAME" --state open --json number --jq 'length')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,43 @@ on:
         default: false
 
 jobs:
+  check-pr-exists:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      has_pr: ${{ steps.check.outputs.has_pr }}
+    steps:
+      - name: Проверка наличия pull request для ветки
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -e
+          # При push в ветку, для которой уже открыт pull request, тесты будут
+          # запущены в рамках события pull_request, поэтому повторный запуск
+          # для события push пропускается во избежание дублирования прогонов.
+          if [ "$EVENT_NAME" == "push" ] \
+            && [ "$REF_NAME" != "$DEFAULT_BRANCH" ] \
+            && [ "$REF_NAME" != "master" ] \
+            && [ "$REF_NAME" != "develop" ]; then
+            prs=$(gh pr list --repo "$REPOSITORY" --head "$REF_NAME" --state open --json number --jq 'length')
+            if [ "$prs" -gt 0 ]; then
+              echo "has_pr=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_pr=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: [check-pr-exists]
+    if: needs.check-pr-exists.outputs.has_pr != 'true'
     runs-on: ${{ matrix.os }}
     env:
       LANG: ${{ inputs.locale }}.UTF-8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,7 @@ jobs:
           # для события push пропускается во избежание дублирования прогонов.
           if [ "$EVENT_NAME" == "push" ] \
             && [ "$REF_NAME" != "$DEFAULT_BRANCH" ] \
+            && [ "$REF_NAME" != "main" ] \
             && [ "$REF_NAME" != "master" ] \
             && [ "$REF_NAME" != "develop" ]; then
             prs=$(gh pr list --repo "$REPOSITORY" --head "$REF_NAME" --state open --json number --jq 'length')

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ lib.system=../oscript_modules
 Сборочная линия для выполнения тестирования библиотеки. Позволяет запустить матричную сборку на настраиваемом списке операционных систем (по умолчанию Windows, Ubuntu и macOS) на нескольких версиях движка OneScript. Поддерживается запуск из ветки, из pull request и ручной запуск из информации о конкретном workflow.
 
 > [!NOTE]
-> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, тестирование пропускается — оно будет выполнено в рамках события `pull_request`. Для ветки по умолчанию (а также `master` и `develop`) тестирование выполняется всегда.
+> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, тестирование пропускается — оно будет выполнено в рамках события `pull_request`. Для ветки по умолчанию (а также `main`, `master` и `develop`) тестирование выполняется всегда.
 
 Файл workflow: [https://github.com/autumn-library/workflows/blob/main/.github/workflows/test.yml](https://github.com/autumn-library/workflows/blob/main/.github/workflows/test.yml)
 
@@ -212,7 +212,7 @@ jobs:
 > Анализ pull request из форков для задачи SonarQube пока не поддерживается.
 
 > [!NOTE]
-> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, контроль качества пропускается — он будет выполнен в рамках события `pull_request`. Для ветки по умолчанию (а также `master` и `develop`) контроль качества выполняется всегда.
+> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, контроль качества пропускается — он будет выполнен в рамках события `pull_request`. Для ветки по умолчанию (а также `main`, `master` и `develop`) контроль качества выполняется всегда.
 
 Файл workflow: [https://github.com/autumn-library/workflows/blob/main/.github/workflows/sonar.yml](https://github.com/autumn-library/workflows/blob/main/.github/workflows/sonar.yml)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ lib.system=../oscript_modules
 
 Сборочная линия для выполнения тестирования библиотеки. Позволяет запустить матричную сборку на настраиваемом списке операционных систем (по умолчанию Windows, Ubuntu и macOS) на нескольких версиях движка OneScript. Поддерживается запуск из ветки, из pull request и ручной запуск из информации о конкретном workflow.
 
+> [!NOTE]
+> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, тестирование пропускается — оно будет выполнено в рамках события `pull_request`. Для ветки по умолчанию (а также `master` и `develop`) тестирование выполняется всегда.
+
 Файл workflow: [https://github.com/autumn-library/workflows/blob/main/.github/workflows/test.yml](https://github.com/autumn-library/workflows/blob/main/.github/workflows/test.yml)
 
 Общие параметры:
@@ -207,6 +210,9 @@ jobs:
 Сборочная линия для выполнения анализа качества кода с помощью SonarQube и отправки данных о покрытии в [coveralls](https://coveralls.io).  
 Поддерживается запуск из ветки, из pull request и ручной запуск из информации о конкретном workflow.  
 > Анализ pull request из форков для задачи SonarQube пока не поддерживается.
+
+> [!NOTE]
+> Чтобы избежать двойного прогона, при событии `push` в ветку, для которой уже открыт pull request, контроль качества пропускается — он будет выполнен в рамках события `pull_request`. Для ветки по умолчанию (а также `master` и `develop`) контроль качества выполняется всегда.
 
 Файл workflow: [https://github.com/autumn-library/workflows/blob/main/.github/workflows/sonar.yml](https://github.com/autumn-library/workflows/blob/main/.github/workflows/sonar.yml)
 


### PR DESCRIPTION
Перенесена логика из 1c-syntax/bsl-language-server: при событии push в ветку,
для которой уже открыт pull request, тестирование и контроль качества
пропускаются, чтобы избежать дублирующего прогона (он будет выполнен в рамках
события pull_request).

Логика реализована встроенным job check-pr-exists в reusable-workflow'ах
test.yml и sonar.yml. В отличие от исходного репозитория используется
динамическое определение ветки по умолчанию (github.event.repository.default_branch),
а не внешний скрипт, недоступный в контексте вызывающего репозитория.

https://claude.ai/code/session_01BWWiueTXPbduaFtruKmkAv